### PR TITLE
Refactor `DSL.clone` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,52 +5,74 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.5] - 2025-08-05
+## [2.1.6] - 2025-08-21
+
 ### Changed
+
+- Refactored `DSL.clone` to create a new instance with deep-cloned data, pipeline, rules, and functions, ensuring unique IDs and proper separation of state.
+
+### Added
+
+- Expanded `.clone()` test coverage to verify instance separation, message array independence, rule/type preservation, mutation isolation, and independent execution.
+
+## [2.1.5] - 2025-08-05
+
+### Changed
+
 - The maximum number of allowed function calls per stage is now determined by `this.settings.maxCallStack` instead of a hardcoded value.
 
 ### Fixed
+
 - Fixed a bug where a function call was being inserted before the stage that requested it, causing a loop between the requesting stage and the function call. Now, function calls are correctly appended to the pipeline after the requesting stage.
 
 ## [2.1.1] - 2024-07-27
+
 ### Added
+
 - Implemented a new function `call` - allows you to programatically trigger a function provided by to the LLM.
 - New Argument to `clone` - when cloning you can specify whether the cloned DSL should start at the `beginning`, `end` or a specific position of the pipeline.
 - A message is now added to the chat indicating the LLM called a function with including the args. This message will have the role `system`.
 
 ### Changed
+
 - Moved the functionality of `push` to `append`.
 - Changed the functionality of `push` - now adds a message after the current pipeline position without generating a prompt. Prior to this change, the message would be appended to the pipeline (functionality still exists with `append`).
 - Changed the content format for function responses removing the text `call ${ name }() ->`.
 
 ### Fixes
+
 - Hallucination of how to call a function available to the LLM.
 
-##  [2.0.2] - 2024-04-02
+## [2.0.2] - 2024-04-02
+
 ### Added
+
 - New attribute: `Message.functions` - an optional object listing key value pairs of the function name and the number of input tokens. An additional key `Message.functions.total` will be included indicating the total tokens used by functions.
 - New Argument to `#prompt`: `functions` - a falsy value indicating whether functions should be excluded on an individual prompt.
 - The instance of LLM now includes abstract functions for `windowTokens`, `functionTokens` and `close`. Both the `windowTokens` and `functionTokens` were extracted from the DSL and provied to the LLM as each may calculate these differently.
-- New Feature to `Window` - this now accepts an addition argument `chat` which gives the `window` function the ability to access additional data specifically the LLMs `windowTokens` function. 
+- New Feature to `Window` - this now accepts an addition argument `chat` which gives the `window` function the ability to access additional data specifically the LLMs `windowTokens` function.
 
 ### Fixed
-- summarizing `Chat.inputs` and `Chat.outputs`. All messages with role `assistant` are summarized in `Chat.outputs` all other messages will be `Chat.inputs`.
 
+- summarizing `Chat.inputs` and `Chat.outputs`. All messages with role `assistant` are summarized in `Chat.outputs` all other messages will be `Chat.inputs`.
 
 ## [2.0.1] - 2024-03-26
 
 ### Added
+
 - `stream` now supports multiple `StreamHandlers` as `rest` arguments.
 - `expect` now supports multiple `ResonseStages` as `rest` arguments.
 - New type `Window` which enables a custom windowing function.
 - New `pipeline` management features: `moveTo`, `exit`, `pause`.
 
 ### Changed
+
 below describes the changes made to the `Chat` interface
+
 - Visibility Enum: `Visibility.OPTIONAL` = `0`; `Visibility.SYSTEM` = `1`; Prior to this release, the values were swapped.
 - `Message.included` was renamed to `Message.window`
 - `Message.tokens` was renamed to `Message.size`
 - `Chat.metadata` is now typed.whether a token was part of the input promopt or the output response. Models charge differently for each.
 - New attribute: `Message.prompt` which will identify what prompt or other stage generated the message.
 - New attribute: `Message.windowSize`
-- New attribute: `Chat.inputs` and `Chat.outputs` which summarize the tokens within the chat and diffirentiate 
+- New attribute: `Chat.inputs` and `Chat.outputs` which summarize the tokens within the chat and diffirentiate

--- a/__tests__/clone.test.ts
+++ b/__tests__/clone.test.ts
@@ -9,4 +9,59 @@ describe( ".clone()", () => {
     const $clone = chat.clone();
     expect( Object.is( $clone, chat ) ).toBe( false );
   } );
+
+  it( "clone is instance of DSL", () => {
+    const $clone = chat.clone();
+    expect( $clone ).toBeInstanceOf( DSL );
+  } );
+
+  it( "clone has different id", () => {
+    const $clone = chat.clone();
+    expect( $clone.data.id ).not.toBe( chat.data.id );
+  } );
+
+  it( "clone has separate messages array", () => {
+    chat.data.messages.push( {
+      id: "msg1",
+      key: "msg1",
+      role: "user",
+      content: "hi",
+      size: 2,
+      visibility: 0,
+      createdAt: new Date(),
+      prompt: "msg1"
+    } );
+    const $clone = chat.clone();
+    expect( $clone.data.messages ).not.toBe( chat.data.messages );
+    expect( $clone.data.messages.length ).toBe( chat.data.messages.length );
+  } );
+
+  it( "clone preserves rules and type", () => {
+    chat.rules.push( "rule1" );
+    chat.type = "sidebar";
+    const $clone = chat.clone();
+    expect( $clone.rules ).toEqual( chat.rules );
+    expect( $clone.type ).toBe( chat.type );
+  } );
+
+  it( "mutating clone does not affect original", () => {
+    const $clone = chat.clone();
+    $clone.data.messages.push( {
+      id: "msg2",
+      key: "msg2",
+      role: "user",
+      content: "bye",
+      size: 2,
+      visibility: 0,
+      createdAt: new Date(),
+      prompt: "msg2"
+    } );
+    expect( chat.data.messages.find( m => m.id === "msg2" ) ).toBeUndefined();
+  } );
+
+  it( "clone can execute independently", async () => {
+    const $clone = chat.clone();
+    $clone.pipeline.push( { id: "p3", stage: "test", promise: async () => { } } );
+    await expect( $clone.execute() ).resolves.toBe( $clone );
+  } );
 } );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k-apps-io/llm-dsl",
-  "version": "2.1.5",
+  "version": "2.1.6-beta.1",
   "description": "a DSL for Large Language Models (LLM)",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Refactor `DSL.clone` for deep cloning and enhance test coverage for instance separation and mutation isolation